### PR TITLE
App envs

### DIFF
--- a/pkg/application/convert_test.go
+++ b/pkg/application/convert_test.go
@@ -27,13 +27,13 @@ func TestConvertToBundle(t *testing.T) {
 						Type:     "foo",
 						Field:    "some-field",
 						Required: false,
-						Env:      []application.ApplicationDependenciesEnvs{},
+						Envs:      []application.ApplicationDependenciesEnvs{},
 					},
 					{
 						Type:     "bar",
 						Field:    "another-field",
 						Required: true,
-						Env:      []application.ApplicationDependenciesEnvs{},
+						Envs:      []application.ApplicationDependenciesEnvs{},
 					},
 				},
 				Params: map[string]interface{}{

--- a/pkg/application/convert_test.go
+++ b/pkg/application/convert_test.go
@@ -27,13 +27,13 @@ func TestConvertToBundle(t *testing.T) {
 						Type:     "foo",
 						Field:    "some-field",
 						Required: false,
-						Envs:      []application.ApplicationDependenciesEnvs{},
+						Envs:     []application.ApplicationDependenciesEnvs{},
 					},
 					{
 						Type:     "bar",
 						Field:    "another-field",
 						Required: true,
-						Envs:      []application.ApplicationDependenciesEnvs{},
+						Envs:     []application.ApplicationDependenciesEnvs{},
 					},
 				},
 				Params: map[string]interface{}{

--- a/pkg/application/parse_test.go
+++ b/pkg/application/parse_test.go
@@ -97,7 +97,7 @@ func TestParse(t *testing.T) {
 						Type:     "massdriver/rdbms-authentication",
 						Field:    "database",
 						Required: true,
-						Env: []application.ApplicationDependenciesEnvs{
+						Envs: []application.ApplicationDependenciesEnvs{
 							{
 								Name: "DATABASE_URL",
 								Path: ".data.authentication.connection_string",
@@ -108,7 +108,7 @@ func TestParse(t *testing.T) {
 						Type:     "massdriver/aws-sqs-queue",
 						Field:    "queue",
 						Required: false,
-						Env: []application.ApplicationDependenciesEnvs{
+						Envs: []application.ApplicationDependenciesEnvs{
 							{
 								Name: "MY_QUEUE_ARN",
 								Path: ".data.infrastructure.arn",

--- a/pkg/application/testdata/appdeps.yaml
+++ b/pkg/application/testdata/appdeps.yaml
@@ -4,7 +4,7 @@ description: An application
 ref: github.com/user/app
 access: private
 
-deployment: 
+deployment:
   type: simple
 
 params:
@@ -17,17 +17,17 @@ params:
       type: integer
       title: Age
 
-dependencies: 
+dependencies:
   - type: massdriver/rdbms-authentication
     field: database
     required: true
-    env: 
+    envs:
       - name: DATABASE_URL
         path: .data.authentication.connection_string
   - type: massdriver/aws-sqs-queue
     field: queue
     required: false
-    env: 
+    envs:
       - name: MY_QUEUE_ARN
         path: .data.infrastructure.arn
     policy: read

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -22,7 +22,7 @@ type ApplicationDependencies struct {
 	Type     string                        `json:"type" yaml:"type"`
 	Field    string                        `json:"field" yaml:"field"`
 	Required bool                          `json:"required,omitempty" yaml:"required,omitempty"`
-	Env      []ApplicationDependenciesEnvs `json:"env" yaml:"env"`
+	Envs     []ApplicationDependenciesEnvs `json:"envs" yaml:"envs"`
 	Policy   string                        `json:"policy,omitempty" yaml:"policy,omitempty"`
 }
 


### PR DESCRIPTION
Terraform expects `envs`, `envs` is better for an array than `env`. This is the last thing to make app dependencies work again. 🥳 