### PR TITLE
updating policy field to support an array

### DIFF
--- a/pkg/application/parse_test.go
+++ b/pkg/application/parse_test.go
@@ -103,6 +103,7 @@ func TestParse(t *testing.T) {
 								Path: ".data.authentication.connection_string",
 							},
 						},
+						Policies: []string{"read-bq", "read-gcs"},
 					},
 					{
 						Type:     "massdriver/aws-sqs-queue",
@@ -114,7 +115,7 @@ func TestParse(t *testing.T) {
 								Path: ".data.infrastructure.arn",
 							},
 						},
-						Policy: "read",
+						Policies: []string{"read"},
 					},
 				},
 			},

--- a/pkg/application/testdata/appdeps.yaml
+++ b/pkg/application/testdata/appdeps.yaml
@@ -24,10 +24,14 @@ dependencies:
     envs:
       - name: DATABASE_URL
         path: .data.authentication.connection_string
+    policies:
+     - read-bq
+     - read-gcs
   - type: massdriver/aws-sqs-queue
     field: queue
     required: false
     envs:
       - name: MY_QUEUE_ARN
         path: .data.infrastructure.arn
-    policy: read
+    policies:
+      - read

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -23,7 +23,7 @@ type ApplicationDependencies struct {
 	Field    string                        `json:"field" yaml:"field"`
 	Required bool                          `json:"required,omitempty" yaml:"required,omitempty"`
 	Envs     []ApplicationDependenciesEnvs `json:"envs" yaml:"envs"`
-	Policy   string                        `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Policies   []string                    `json:"policies,omitempty" yaml:"policies,omitempty"`
 }
 
 type ApplicationDependenciesEnvs struct {


### PR DESCRIPTION
This helps answer the question around the iam `condition` per role in the Security Bloc [design doc](https://massdriver.slab.com/posts/artifact-security-blocks-vbnzyvvh#h0p17-gcp).

```
{
  "security": {
    "iam": {
       "read-bq": {
         "roles": ["roles/bq.read"],
         "condition": "etc.."
       },
      "read-gcs": {
        "roles": ["roles/gcs.read"],
         "condition": "etc.."
       }
    }
  }
}
```