### PR TITLE
Default steps if not present

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/pkg/bundle/parse.go
+++ b/pkg/bundle/parse.go
@@ -20,5 +20,15 @@ func Parse(path string) (*Bundle, error) {
 		return nil, err
 	}
 
+	setDefaultSteps(bundle)
+
 	return bundle, nil
+}
+
+// Sets the default steps to be a single src dir for terraform
+func setDefaultSteps(bundle *Bundle) {
+	if len(bundle.Steps) == 0 {
+		defaultStep := BundleStep{Path: "src", Provisioner: "terraform"}
+		bundle.Steps = []BundleStep{defaultStep}
+	}
 }

--- a/pkg/bundle/parse_test.go
+++ b/pkg/bundle/parse_test.go
@@ -15,7 +15,10 @@ func TestParseBundle(t *testing.T) {
 		Name:        "aws-vpc",
 		Description: "Something",
 		Access:      "public",
-		Artifacts:   map[string]interface{}{},
+		Steps: []bundle.BundleStep{
+			bundle.BundleStep{Path: "src", Provisioner: "terraform"},
+		},
+		Artifacts: map[string]interface{}{},
 		Params: map[string]interface{}{
 			"properties": map[string]interface{}{
 				"name": map[string]interface{}{

--- a/pkg/bundle/templates/terraform/massdriver.yaml
+++ b/pkg/bundle/templates/terraform/massdriver.yaml
@@ -6,10 +6,6 @@ ref: github.com/YOUR_NAME_HERE/{{ .Name }}
 access: "{{ .Access }}"
 type: "{{ .Type }}"
 
-steps:
-  - path: src
-    provisioner: terraform
-
 # schema-params.json
 # JSON Schema sans-fields above
 params:


### PR DESCRIPTION
We should default the steps to `src` and `terraform` when not present in the file and exclude them from the bundle generator.

This will let us hide this feature from users for now so people don't depend on it since it can be destructive in the even they change their `path`.

It also makes the standard bundle file a little shorter for something the average users won't need to change.