### PR TITLE
Cmd line override of access

### DIFF
--- a/pkg/application/package.go
+++ b/pkg/application/package.go
@@ -16,8 +16,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// TODO: we need to add support for access overrides to applications as well
-// Remove comment in PR via GH suggestion and open issue.
 func PackageApplication(appPath string, c *client.MassdriverClient, workingDir string, buf io.Writer) (*bundle.Bundle, error) {
 	app, err := Parse(appPath)
 	if err != nil {

--- a/pkg/application/package.go
+++ b/pkg/application/package.go
@@ -16,6 +16,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// TODO: we need to add support for access overrides to applications as well
+// Remove comment in PR via GH suggestion and open issue.
 func PackageApplication(appPath string, c *client.MassdriverClient, workingDir string, buf io.Writer) (*bundle.Bundle, error) {
 	app, err := Parse(appPath)
 	if err != nil {

--- a/pkg/bundle/parse.go
+++ b/pkg/bundle/parse.go
@@ -34,7 +34,6 @@ func Parse(path string, overrides map[string]interface{}) (*Bundle, error) {
 func applyOverrides(b *Bundle, overrides map[string]interface{}) {
 	if access, found := overrides["access"]; found {
 		// TODO: we need to add a meta schema for our metadata and validate the bundle
-		// Remove comment in PR via GH suggestion and open issue.
 		if access == "public" || access == "private" {
 			b.Access = access.(string)
 		}

--- a/pkg/bundle/parse.go
+++ b/pkg/bundle/parse.go
@@ -6,8 +6,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type BundleOverrides struct {
+	Access string
+}
+
 // ParseBundle parses a bundle from a YAML file
-func Parse(path string) (*Bundle, error) {
+// overrides allow the CLI to override specific bundle metadata.
+// This is useful in a CI/CD scenario when you want to change the `access` if you are deploying to a sandbox org.
+func Parse(path string, overrides map[string]interface{}) (*Bundle, error) {
 	bundle := new(Bundle)
 
 	data, err := ioutil.ReadFile(path)
@@ -20,5 +26,17 @@ func Parse(path string) (*Bundle, error) {
 		return nil, err
 	}
 
+	applyOverrides(bundle, overrides)
+
 	return bundle, nil
+}
+
+func applyOverrides(b *Bundle, overrides map[string]interface{}) {
+	if access, found := overrides["access"]; found {
+		// TODO: we need to add a meta schema for our metadata and validate the bundle
+		// Remove comment in PR via GH suggestion and open issue.
+		if access == "public" || access == "private" {
+			b.Access = access.(string)
+		}
+	}
 }

--- a/pkg/bundle/parse.go
+++ b/pkg/bundle/parse.go
@@ -33,7 +33,6 @@ func Parse(path string, overrides map[string]interface{}) (*Bundle, error) {
 
 func applyOverrides(b *Bundle, overrides map[string]interface{}) {
 	if access, found := overrides["access"]; found {
-		// TODO: we need to add a meta schema for our metadata and validate the bundle
 		if access == "public" || access == "private" {
 			b.Access = access.(string)
 		}

--- a/pkg/bundle/parse_test.go
+++ b/pkg/bundle/parse_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParseBundle(t *testing.T) {
-	var got, _ = bundle.Parse("./testdata/massdriver.yaml")
+	var got, _ = bundle.Parse("./testdata/massdriver.yaml", nil)
 	var want = bundle.Bundle{
 		Schema:      "draft-07",
 		Type:        "bundle",
@@ -47,5 +47,18 @@ func TestParseBundle(t *testing.T) {
 
 	if !reflect.DeepEqual(*got, want) {
 		t.Errorf("got %v, want %v", *got, want)
+	}
+}
+
+func TestParseBundleWithAccessOverride(t *testing.T) {
+	overrides := map[string]interface{}{
+		"access": "private",
+	}
+	var bundle, _ = bundle.Parse("./testdata/massdriver.yaml", overrides)
+	got := bundle.Access
+	want := "private"
+
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/pkg/bundle/schema_test.go
+++ b/pkg/bundle/schema_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGenerateSchemas(t *testing.T) {
-	var bundle, _ = bundle.Parse("./testdata/bundle.Build/massdriver.yaml")
+	var bundle, _ = bundle.Parse("./testdata/bundle.Build/massdriver.yaml", nil)
 	_ = bundle.GenerateSchemas("./tmp/")
 
 	gotDir, _ := os.ReadDir("./tmp")
@@ -32,7 +32,7 @@ func TestGenerateSchemas(t *testing.T) {
 }
 
 func TestGenerateSchema(t *testing.T) {
-	var b, _ = bundle.Parse("./testdata/bundle.Build/massdriver.yaml")
+	var b, _ = bundle.Parse("./testdata/bundle.Build/massdriver.yaml", nil)
 	var inputIo bytes.Buffer
 
 	bundle.GenerateSchema(b.Params, b.Metadata("params"), &inputIo)


### PR DESCRIPTION
Enable the ability to override `access` on `mass bundle publish`.

This will allow us in CI to override the value so we can keep sandbox bundles private and official bundles public.