### PR TITLE
Allow precommit to pass if there are no AWS args in the env

### DIFF
--- a/pkg/bundle/templates/terraform/.pre-commit-config.yaml
+++ b/pkg/bundle/templates/terraform/.pre-commit-config.yaml
@@ -47,5 +47,6 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
       - id: no-commit-to-branch
         args: [-b, main]


### PR DESCRIPTION
Keep changes like this in sync w/ our bundles via something like this:
https://github.com/massdriver-cloud/bundle-github-repo-manager/pull/7