### PR TITLE
add validations.json to bundle generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,6 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
       - id: no-commit-to-branch
         args: [-b, main]

--- a/pkg/bundle/generate.go
+++ b/pkg/bundle/generate.go
@@ -24,6 +24,9 @@ func Generate(data *TemplateData) error {
 	templateFiles, _ := fs.Sub(fs.FS(templatesFs), "templates/terraform")
 
 	err := fs.WalkDir(templateFiles, ".", func(filePath string, info fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		outputPath := path.Join(data.OutputDir, filePath)
 		if info.IsDir() {
 			if filePath == "." {

--- a/pkg/bundle/generate_test.go
+++ b/pkg/bundle/generate_test.go
@@ -49,8 +49,12 @@ func TestGenerate(t *testing.T) {
 	expectedContent = regexp.MustCompile("# aws-vpc")
 	assertFileCreatedAndContainsText(t, readmePath, expectedContent)
 
-	terraformPath := fmt.Sprintf("%s/src", templatePath)
-	mainTFPath := fmt.Sprintf("%s/main.tf", terraformPath)
+	srcPath := fmt.Sprintf("%s/src", templatePath)
+	mainTFPath := fmt.Sprintf("%s/main.tf", srcPath)
 	expectedContent = regexp.MustCompile("random_pet")
 	assertFileCreatedAndContainsText(t, mainTFPath, expectedContent)
+
+	validationsJSONPath := fmt.Sprintf("%s/validations.json", srcPath)
+	expectedContent = regexp.MustCompile("do_not_delete")
+	assertFileCreatedAndContainsText(t, validationsJSONPath, expectedContent)
 }

--- a/pkg/bundle/templates/terraform/src/validations.json
+++ b/pkg/bundle/templates/terraform/src/validations.json
@@ -1,0 +1,4 @@
+{
+    "__comment": "TODO: populate this document to put restrictions on provisioner actions. this comment can optionally be removed or used to explain the specified restrictions.",
+    "do_not_delete": []
+}


### PR DESCRIPTION
I added this new generated file in the `src/` directory. In theory there could be collision between address space in a bundle steps because they are separate tf states. @chrisghill lmk if this file is expected at top level (next to massdriver.yaml) should be simple to move it.

during this PR I noticed a lot of the files in this repo don't obey the pre-commit and we could use to turn on some more aggressive go linting. I'lll propose those changes in a separate PR. 