### PR TITLE
provide more info for 404 of artifacts

### DIFF
--- a/pkg/definition/get.go
+++ b/pkg/definition/get.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"path"
 
 	"github.com/massdriver-cloud/massdriver-cli/pkg/client"
@@ -31,7 +32,7 @@ func GetDefinition(c *client.MassdriverClient, definitionType string) (map[strin
 		return definition, err
 	}
 
-	if resp.StatusCode != http.StatusOk {
+	if resp.StatusCode != http.StatusOK {
 		fmt.Println(string(respBodyBytes))
 		return definition, errors.New("received non-200 response from Massdriver: " + resp.Status + " " + definitionType)
 	}

--- a/pkg/definition/get.go
+++ b/pkg/definition/get.go
@@ -33,7 +33,7 @@ func GetDefinition(c *client.MassdriverClient, definitionType string) (map[strin
 
 	if resp.Status != "200 OK" {
 		fmt.Println(string(respBodyBytes))
-		return definition, errors.New("received non-200 response from Massdriver: " + resp.Status)
+		return definition, errors.New("received non-200 response from Massdriver: " + resp.Status + " " + definitionType)
 	}
 
 	err = json.Unmarshal(respBodyBytes, &definition)

--- a/pkg/definition/get.go
+++ b/pkg/definition/get.go
@@ -31,7 +31,7 @@ func GetDefinition(c *client.MassdriverClient, definitionType string) (map[strin
 		return definition, err
 	}
 
-	if resp.Status != "200 OK" {
+	if resp.StatusCode != http.StatusOk {
 		fmt.Println(string(respBodyBytes))
 		return definition, errors.New("received non-200 response from Massdriver: " + resp.Status + " " + definitionType)
 	}

--- a/pkg/definition/get.go
+++ b/pkg/definition/get.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path"
@@ -33,7 +32,6 @@ func GetDefinition(c *client.MassdriverClient, definitionType string) (map[strin
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		fmt.Println(string(respBodyBytes))
 		return definition, errors.New("received non-200 response from Massdriver: " + resp.Status + " " + definitionType)
 	}
 

--- a/pkg/jsonschema/hydrate.go
+++ b/pkg/jsonschema/hydrate.go
@@ -3,6 +3,7 @@ package jsonschema
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -117,6 +118,10 @@ func hydrateHTTPRef(ctx context.Context, c *client.MassdriverClient, hydratedSch
 	if doErr != nil {
 		return hydratedSchema, doErr
 	}
+	if resp.StatusCode != http.StatusOK {
+		return hydratedSchema, errors.New("received non-200 response getting ref " + resp.Status + " " + schemaRefValue)
+	}
+
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
See the comments below for the yamls I used to test after writing tests for these. 

## Better-errors

I checked:

- massdriver ref
  - added code, added test
- http ref
  - added code, added test 
- local ref
  - the error was already informative, so I didn't add anything. 

## CLI Interface - Usage

I didn't check these changes in, but when an error is returned, CLI usage is printed out. I haven't seen this before in a CLI for an error, just for improper usage. When you type `mass bun build` then a helpful message is displayed. I think it's a better experience to not show usage when there's an internal CLI error.

*existing*
```
mass bundle build
{"level":"error","error":"open /Users/wbeebe/repos/massdriver-cloud/_test-hydrate/types/my-local-yolo-type.json: no such file or directory","time":"2022-07-09T15:10:31-07:00","message":"an error occurred while hydrating bundle"}
Usage:
  mass bundle build [flags]

Flags:
  -h, --help            help for build
  -o, --output string   Path to output directory (default is massdriver.yaml directory)

Global Flags:
  -k, --api-key string   Massdriver API key (can also be set via MASSDRIVER_API_KEY environment variable)
  -v, --verbose          Enable verbose output
```

*with* `SilenceUsage:  true,`
```
mass bundle build
{"level":"error","error":"open /Users/wbeebe/repos/massdriver-cloud/_test-hydrate/types/my-local-yolo-type.json: no such file or directory","time":"2022-07-09T15:10:31-07:00","message":"an error occurred while hydrating bundle"}
```

When a user is not using the CLI properly. I think this is good!
```
mass bun build
Error: unknown command "bun" for "mass"

Did you mean this?
	bundle

Run 'mass --help' for usage.
```

## CLI Interface - Errors

Right now, if an error is returned, it is printed twice. 

*existing*
```
{"level":"error","error":"open /Users/wbeebe/repos/massdriver-cloud/_test-hydrate/types/my-local-yolo-type.json: no such file or directory","time":"2022-07-09T15:14:03-07:00","message":"an error occurred while hydrating bundle"}
Error: open /Users/wbeebe/repos/massdriver-cloud/_test-hydrate/types/my-local-yolo-type.json: no such file or directory
```

*with* `SilenceErrors: true,`

```
mass bundle build
{"level":"error","error":"open /Users/wbeebe/repos/massdriver-cloud/_test-hydrate/types/my-local-yolo-type.json: no such file or directory","time":"2022-07-09T15:10:31-07:00","message":"an error occurred while hydrating bundle"}
```

I think 

+ twice isn't good
+ json is easier to parse when the cli is running in CI/CD w/o a human
+ non-json is more human-CLI friendly
  + to support this, we wouldn't use `SilenceErrors: true` we'd _not_ print the error at the top level of Cobra. We'd lean on the `loggingSetup` printing _I'm pretty sure_
Thoughts?
