### PR TITLE
test release workflow on pre-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,8 @@ on:
   release:
     types:
       - created
+      - published
+      - released
 jobs:
   generate:
     name: Generate cross-platform builds


### PR DESCRIPTION
from: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
```
Note: The prereleased type will not trigger for pre-releases published from draft releases, but the published type will trigger. If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased.
```