### PR TITLE
remove double quotes on ldflags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,4 +25,4 @@ jobs:
         goversion: 1.17
         binary_name: mass
         # ldflags is the canonical way of setting dynamic values (like version) at compile time
-        ldflags: "-X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${GITHUB_REF_NAME} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitCommit=${GITHUB_SHA}"
+        ldflags: -X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${GITHUB_REF_NAME} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitCommit=${GITHUB_SHA}


### PR DESCRIPTION
this seems to be preventing shell env var expansion in release flow