### PR TITLE
double braces, deduplicate runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ on:
   release:
     types:
       - created
-      - published
       - released
 jobs:
   generate:
@@ -25,4 +24,4 @@ jobs:
         goversion: 1.17
         binary_name: mass
         # ldflags is the canonical way of setting dynamic values (like version) at compile time
-        ldflags: -X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${GITHUB_REF_NAME} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitCommit=${GITHUB_SHA}
+        ldflags: -X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${{GITHUB_REF_NAME}} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitSHA=${{GITHUB_SHA}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,4 +24,4 @@ jobs:
         goversion: 1.17
         binary_name: mass
         # ldflags is the canonical way of setting dynamic values (like version) at compile time
-        ldflags: -X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${{env.GITHUB_REF_NAME}} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitSHA=${{env.GITHUB_SHA}}
+        ldflags: -X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${{github.ref_name}} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitSHA=${{github.sha}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,4 +24,4 @@ jobs:
         goversion: 1.17
         binary_name: mass
         # ldflags is the canonical way of setting dynamic values (like version) at compile time
-        ldflags: -X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${{GITHUB_REF_NAME}} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitSHA=${{GITHUB_SHA}}
+        ldflags: -X github.com/massdriver-cloud/massdriver-cli/pkg/version.version=${{env.GITHUB_REF_NAME}} -X github.com/massdriver-cloud/massdriver-cli/pkg/version.gitSHA=${{env.GITHUB_SHA}}


### PR DESCRIPTION
ok this finally fixes our release flow
you can check it out for yourself by looking at this pre-release https://github.com/massdriver-cloud/massdriver-cli/releases/tag/v0.1.1-rc.7

downloaded artifact should produce this expected output for the most recent commit to the branch
```
$ ~/Downloads/mass version
mass version: v0.1.1-rc.7 (git SHA: 55ac1a330b3bc47c05022cfcf3316d9781291ca4)
```