### PR TITLE
Add capability to override Massdriver API base URL with environment variable

### DIFF
--- a/pkg/application/package_test.go
+++ b/pkg/application/package_test.go
@@ -59,7 +59,7 @@ func TestPackage(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			c := client.NewClient().WithEndpoint(testServer.URL)
+			c := client.NewClient().WithBaseURL(testServer.URL)
 
 			// Create a temp dir, write out the archive, then shell out to untar
 			testDir := t.TempDir()

--- a/pkg/bundle/publish_test.go
+++ b/pkg/bundle/publish_test.go
@@ -62,7 +62,7 @@ func TestPublish(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			c := client.NewClient().WithEndpoint(testServer.URL)
+			c := client.NewClient().WithBaseURL(testServer.URL)
 
 			gotResponse, err := tc.bundle.Publish(c)
 			if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,18 +11,18 @@ type HTTPClient interface {
 }
 
 type MassdriverClient struct {
-	Client   HTTPClient
-	endpoint string
-	apiKey   string
+	Client  HTTPClient
+	baseURL string
+	apiKey  string
 }
 
-const MassdriverEndpoint = "https://api.massdriver.cloud"
+const MassdriverBaseURL = "https://api.massdriver.cloud"
 
 func NewClient() *MassdriverClient {
 	c := new(MassdriverClient)
 
 	c.Client = http.DefaultClient
-	c.endpoint = MassdriverEndpoint
+	c.baseURL = getBaseURL()
 	c.apiKey = getAPIKey()
 
 	return c
@@ -33,13 +33,20 @@ func getAPIKey() string {
 	return os.Getenv("MASSDRIVER_API_KEY")
 }
 
+func getBaseURL() string {
+	if endpoint, ok := os.LookupEnv("MASSDRIVER_URL"); ok {
+		return endpoint
+	}
+	return MassdriverBaseURL
+}
+
 func (c *MassdriverClient) WithAPIKey(apiKey string) *MassdriverClient {
 	c.apiKey = apiKey
 	return c
 }
 
-func (c *MassdriverClient) WithEndpoint(endpoint string) *MassdriverClient {
-	c.endpoint = endpoint
+func (c *MassdriverClient) WithBaseURL(endpoint string) *MassdriverClient {
+	c.baseURL = endpoint
 	return c
 }
 

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -25,7 +25,7 @@ func NewRequest(method string, path string, body io.Reader) *Request {
 }
 
 func (req *Request) ToHTTPRequest(ctx context.Context, c *MassdriverClient) (*http.Request, error) {
-	url, err := url.Parse(c.endpoint)
+	url, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/definition/get_test.go
+++ b/pkg/definition/get_test.go
@@ -43,7 +43,7 @@ func TestGet(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			c := client.NewClient().WithEndpoint(testServer.URL)
+			c := client.NewClient().WithBaseURL(testServer.URL)
 
 			got, err := definition.GetDefinition(c, "massdriver/test-schema")
 			if err != nil {

--- a/pkg/definition/publish_test.go
+++ b/pkg/definition/publish_test.go
@@ -41,7 +41,7 @@ func TestPublish(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			c := client.NewClient().WithEndpoint(testServer.URL)
+			c := client.NewClient().WithBaseURL(testServer.URL)
 
 			err := tc.definition.Publish(c)
 			if err != nil {

--- a/pkg/jsonschema/hydrate_test.go
+++ b/pkg/jsonschema/hydrate_test.go
@@ -126,7 +126,7 @@ func TestHydrate(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			c := client.NewClient().WithEndpoint(testServer.URL)
+			c := client.NewClient().WithBaseURL(testServer.URL)
 			ctx := context.TODO()
 
 			got, gotErr := jsonschema.Hydrate(ctx, test.Input, ".", c)
@@ -169,7 +169,7 @@ func TestHydrate(t *testing.T) {
 		}))
 		defer testServer.Close()
 
-		c := client.NewClient().WithEndpoint(testServer.URL)
+		c := client.NewClient().WithBaseURL(testServer.URL)
 		ctx := context.TODO()
 
 		recursive := fmt.Sprintf(`{"baz":{"$ref":"%s/endpoint"}}`, testServer.URL)


### PR DESCRIPTION
Add the ability to override the Massdriver API URL using an environment variable (`MASSDRIVER_URL`). This allow us to use local development servers for artifacts or other capabilities.

Relates to: https://github.com/massdriver-cloud/artifact-definitions/pull/100