### PR TITLE
Hide alpha templates from display

### DIFF
--- a/pkg/application/prompt.go
+++ b/pkg/application/prompt.go
@@ -145,6 +145,7 @@ func getOutputDir(t *template.Data) error {
 	return nil
 }
 
+// note, does not preserve ordering
 func remove(s []string, i int) []string {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]

--- a/pkg/application/prompt.go
+++ b/pkg/application/prompt.go
@@ -95,8 +95,12 @@ func getDescription(t *template.Data) error {
 	return nil
 }
 
+var IgnoredTemplateDirs = []string{"alpha"}
+
 func getTemplate(t *template.Data) error {
 	templates, err := cache.ApplicationTemplates()
+	templates = removeIgnoredTemplateDirectories(templates, IgnoredTemplateDirs)
+
 	if err != nil {
 		return err
 	}
@@ -113,6 +117,21 @@ func getTemplate(t *template.Data) error {
 
 	t.TemplateName = result
 	return nil
+}
+
+func removeIgnoredTemplateDirectories(templates []string, remove []string) []string {
+	for i := 0; i < len(templates); i++ {
+		template := templates[i]
+		for _, rem := range remove {
+			if template == rem {
+				templates = append(templates[:i], templates[i+1:]...)
+				i--
+				break
+			}
+		}
+	}
+
+	return templates
 }
 
 func getOutputDir(t *template.Data) error {

--- a/pkg/application/prompt.go
+++ b/pkg/application/prompt.go
@@ -95,11 +95,11 @@ func getDescription(t *template.Data) error {
 	return nil
 }
 
-var IgnoredTemplateDirs = []string{"alpha"}
+var ignoredTemplateDirs = map[string]bool{"alpha": true}
 
 func getTemplate(t *template.Data) error {
 	templates, err := cache.ApplicationTemplates()
-	templates = removeIgnoredTemplateDirectories(templates, IgnoredTemplateDirs)
+	templates = removeIgnoredTemplateDirectories(templates)
 
 	if err != nil {
 		return err
@@ -119,15 +119,10 @@ func getTemplate(t *template.Data) error {
 	return nil
 }
 
-func removeIgnoredTemplateDirectories(templates []string, remove []string) []string {
-	for i := 0; i < len(templates); i++ {
-		template := templates[i]
-		for _, rem := range remove {
-			if template == rem {
-				templates = append(templates[:i], templates[i+1:]...)
-				i--
-				break
-			}
+func removeIgnoredTemplateDirectories(templates []string) []string {
+	for i, v := range templates {
+		if ignoredTemplateDirs[v] {
+			templates = remove(templates, i)
 		}
 	}
 
@@ -148,4 +143,9 @@ func getOutputDir(t *template.Data) error {
 
 	t.OutputDir = result
 	return nil
+}
+
+func remove(s []string, i int) []string {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
 }


### PR DESCRIPTION
Hides [`alpha`](https://github.com/massdriver-cloud/application-templates/tree/main/alpha/aws-ec2) templates from display.

To opt-in:

```shell
mass app template refresh
MD_DEV_TEMPLATES_PATH="~/work/application-templates/alpha" mass app new
```