### PR TITLE
add nil protection in deployment error reporting

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -47,7 +47,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-
 	log.Info().Str("deploymentId", deployment.ID).Msgf("Deployment %s", strings.ToLower(deployment.Status))
 	return nil
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -39,9 +39,14 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	deployment, err := api.DeployPackage(client, orgID, name)
 
 	if err != nil {
-		log.Fatal().Err(err).Str("deploymentId", deployment.ID).Msg("Deployment failed")
+		if deployment != nil {
+			log.Fatal().Err(err).Str("deploymentId", deployment.ID).Msg("Deployment failed")
+		} else {
+			log.Fatal().Err(err).Msg("Deployment failed")
+		}
 		return err
 	}
+
 
 	log.Info().Str("deploymentId", deployment.ID).Msgf("Deployment %s", strings.ToLower(deployment.Status))
 	return nil


### PR DESCRIPTION
currently if there's no deployment to get from the backend for some reason the cli panics / crashes in deref of `deployment.ID`.

unfortunately, even when we add this nil protection this doesn't give a ton more useful error info..

```
./bin/mass-linux-amd64 deploy jakegcp-gcpplay-db-dj48
FTL Deployment failed error="Message: 500 Internal Server Error; body: \"{\\\"errors\\\":{\\\"detail\\\":\\\"Internal Server Error\\\"}}\", Locations: []"
```