### PR TITLE
hot fix orgID s/String/ID/ in package getPackage query

### DIFF
--- a/pkg/api/package.go
+++ b/pkg/api/package.go
@@ -84,7 +84,7 @@ func GetPackage(client *graphql.Client, orgID string, name string) (*Package, er
 
 	variables := map[string]interface{}{
 		"name":           graphql.String(name),
-		"organizationId": graphql.String(orgID),
+		"organizationId": graphql.ID(orgID),
 	}
 
 	err := client.Query(context.Background(), &q, variables)


### PR DESCRIPTION
this is needed after migration of graphql IDs https://massdriverworkspace.slack.com/archives/C025G1FEAF9/p1663646627594459