### PR TITLE
overwrite release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Release
-      uses: wangyoucao577/go-release-action@v1.25
+      uses: wangyoucao577/go-release-action@v1.31
       with:
+        overwrite: TRUE
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}


### PR DESCRIPTION
this should make re-running a release workflow not fail on asset name conflict.