### PR TITLE
remove deprecated "type" argument from artifact resource

### DIFF
--- a/pkg/bundle/templates/terraform/src/_artifacts.tf
+++ b/pkg/bundle/templates/terraform/src/_artifacts.tf
@@ -1,7 +1,6 @@
 # resource "massdriver_artifact" "<name>" {
 #   field                = "the field in the artifacts schema"
 #   provider_resource_id = "AWS ARN or K8S SelfLink"
-#   type                 = "file-name-from-artifacts"
 #   name                 = "a contextual name for the artifact"
 #   artifact = jsonencode(
 #     {


### PR DESCRIPTION
Ran into this generating a bundle. 