### PR TITLE
move deploy under app

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -5,44 +5,19 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"os"
-	"strings"
-
-	"github.com/massdriver-cloud/massdriver-cli/pkg/api"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
+// TODO remove mass deploy command entirely during next major release.
 var deployCmd = &cobra.Command{
-	Use:   "deploy",
-	Short: "Deploy a configured package",
-	Long:  ``,
-	Args:  cobra.ExactArgs(1),
-
-	RunE: runDeploy,
+	Use:        "deploy",
+	Short:      "Deploy a configured package",
+	Long:       ``,
+	Args:       cobra.ExactArgs(1),
+	RunE:       RunApplicationDeploy,
+	Deprecated: "`mass deploy` is deprecated and will be removed in a future release; use `mass app deploy` instead",
 }
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
-}
-
-func runDeploy(cmd *cobra.Command, args []string) error {
-	setupLogging(cmd)
-	name := args[0]
-
-	orgID := os.Getenv("MASSDRIVER_ORG_ID")
-	if orgID == "" {
-		log.Fatal().Msg("MASSDRIVER_ORG_ID must be set")
-	}
-
-	client := api.NewClient()
-	deployment, err := api.DeployPackage(client, orgID, name)
-
-	if err != nil {
-		log.Fatal().Err(err).Str("deploymentId", deployment.ID).Msg("Deployment failed")
-		return err
-	}
-
-	log.Info().Str("deploymentId", deployment.ID).Msgf("Deployment %s", strings.ToLower(deployment.Status))
-	return nil
 }


### PR DESCRIPTION
also deprecates top-level deploy command (with message that we will remove in the future)