### PR TITLE
fix so template builds on first run

### DIFF
--- a/pkg/bundle/templates/terraform/massdriver.yaml
+++ b/pkg/bundle/templates/terraform/massdriver.yaml
@@ -9,9 +9,13 @@ type: "<md .Type md>"
 # schema-params.json
 # JSON Schema sans-fields above
 params:
+  # Examples will show up as configuration presets in the UI _and_
+  # they will be used to test configurations of the bundle.
   examples:
-    - foo: US-West 2 VPC
-    - foo: US-East 1 VPC
+    - __name: Development
+      foo: bar
+    - __name: Production
+      foo: foo
   required:
     - foo
   properties:


### PR DESCRIPTION
`mass bundle new` then `mass bundle build` breaks, because the template doesn't have any named examples. 