### PR TITLE
add more to default md_metadata

### DIFF
--- a/pkg/provisioners/terraform/compile.go
+++ b/pkg/provisioners/terraform/compile.go
@@ -182,6 +182,9 @@ func getDevParams(path string) (map[string]interface{}, error) {
 			"md-manifest": bundleName,
 			"md-package":  namePrefix,
 		},
+		"deployment": map[string]interface{}{
+			"id": "local-dev-id",
+		},
 		"observability": map[string]interface{}{
 			"alarm_webhook_url": "https://placeholder.com",
 		},

--- a/pkg/provisioners/terraform/compile_test.go
+++ b/pkg/provisioners/terraform/compile_test.go
@@ -70,6 +70,9 @@ func TestGenerateFiles(t *testing.T) {
             "md-project": "local",
             "md-target": "dev"
         },
+        "deployment": {
+            "id": "local-dev-id"
+        },
         "name_prefix": "local-dev-testbundle-000",
         "observability": {
             "alarm_webhook_url": "https://placeholder.com"
@@ -132,6 +135,9 @@ func TestGenerateFiles(t *testing.T) {
             "md-package": "local-dev-testbundle-broken-000",
             "md-project": "local",
             "md-target": "dev"
+        },
+        "deployment": {
+            "id": "local-dev-id"
         },
         "name_prefix": "local-dev-testbundle-broken-000",
         "observability": {

--- a/pkg/provisioners/terraform/testdata/testbundle/src/_params.auto.tfvars.json
+++ b/pkg/provisioners/terraform/testdata/testbundle/src/_params.auto.tfvars.json
@@ -7,6 +7,9 @@
             "md-project": "local",
             "md-target": "dev"
         },
+        "deployment": {
+            "id": "local-dev-id"
+        },
         "name_prefix": "local-dev-testbundle-000",
         "observability": {
             "alarm_webhook_url": "https://placeholder.com"


### PR DESCRIPTION
Some bundles expect `md_metadta.deployment.id`. Adding this to the boilerplate for our bundle devs.