### PR TITLE
run mass app deploy without a massdriver.yaml file

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -161,18 +161,9 @@ func runApplicationPublish(cmd *cobra.Command, args []string) error {
 func RunApplicationDeploy(cmd *cobra.Command, args []string) error {
 	setupLogging(cmd)
 
-	app, err := application.Parse(common.MassdriverYamlFilename, nil)
-	if err != nil {
-		return err
-	}
-	if !app.IsApplication() {
-		return fmt.Errorf("this command can only be used with bundle type 'application'")
-	}
-	// original
 	name := args[0]
 
 	c := config.Get()
-
 	client := api.NewClient()
 	client2 := api2.NewClient(c.APIKey)
 	deployment, err := api.DeployPackage(client, &client2, c.OrgID, name)


### PR DESCRIPTION
I don't think we need to read the `massdriver.yaml` here, and it's not currently used. Removing this makes `mass app deploy` more CI-able.