### PR TITLE
Mass app new require description

### DIFF
--- a/pkg/application/prompt.go
+++ b/pkg/application/prompt.go
@@ -81,8 +81,16 @@ func getAccessLevel(t *template.Data) error {
 }
 
 func getDescription(t *template.Data) error {
+	validate := func(input string) error {
+		if len(input) == 0 {
+			return errors.New("Description cannot be empty.")
+		}
+		return nil
+	}
+
 	prompt := promptui.Prompt{
-		Label: "Description",
+		Label:    "Description",
+		Validate: validate,
 	}
 
 	result, err := prompt.Run()
@@ -132,7 +140,7 @@ func removeIgnoredTemplateDirectories(templates []string) []string {
 func getOutputDir(t *template.Data) error {
 	prompt := promptui.Prompt{
 		Label:   `Output directory`,
-		Default: t.Name,
+		Default: "massdriver",
 	}
 
 	result, err := prompt.Run()

--- a/pkg/bundle/prompt.go
+++ b/pkg/bundle/prompt.go
@@ -83,8 +83,16 @@ func getAccessLevel(t *template.Data) error {
 }
 
 func getDescription(t *template.Data) error {
+	validate := func(input string) error {
+		if len(input) == 0 {
+			return errors.New("Description cannot be empty.")
+		}
+		return nil
+	}
+
 	prompt := promptui.Prompt{
-		Label: "Description",
+		Label:    "Description",
+		Validate: validate,
 	}
 
 	result, err := prompt.Run()


### PR DESCRIPTION
This is fixing some issues I've scene customers run into when setting up apps.

Apps are likely stored in the same directory as the application code itself, so a `massdriver` subdirectory (`app/massdriver/massdriver.yaml`) makes more sense than using the application name as the subdirectory (`app/app/massdriver.yaml`).

If the description field is empty it gets rejected by the API, so we should prevent empty descriptions when creating a new app/bundle.