### PR TITLE
Fix a bug where 'mass app new' fails if the output directory doesn't …

### DIFF
--- a/pkg/template/files.go
+++ b/pkg/template/files.go
@@ -15,7 +15,6 @@ func WriteToFile(filePath string, template []byte, data *Data) error {
 	json.Unmarshal(inrec, &bindings)
 
 	out, renderErr := engine.ParseAndRender(template, bindings)
-
 	if renderErr != nil {
 		return renderErr
 	}


### PR DESCRIPTION
Need to check if the desired output directory for the application template already exists, and if not create it.